### PR TITLE
[Feat] make email logo reasonable size

### DIFF
--- a/app/utils/email/base_template.py
+++ b/app/utils/email/base_template.py
@@ -64,8 +64,8 @@ class BaseEmailTemplate:
                             <table width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: white; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
                                 <!-- Header with logo -->
                                 <tr>
-                                    <td style="background-color: white; padding: 30px 20px; text-align: center; border-bottom: 3px solid {cls.SECONDARY_COLOR};">
-                                        <img src="{logo_url}" alt="CAP Logo" style="width: 120px; height: 120px;">
+                                    <td style="background-color: white; padding: 10px 10px; text-align: center; border-bottom: 3px solid {cls.SECONDARY_COLOR};">
+                                        <img src="{logo_url}" alt="CAP Logo" style="vertical-align: middle; width: 40px; height: 40px;">
                                     </td>
                                 </tr>
 


### PR DESCRIPTION
After:
<img width="1728" height="993" alt="Screenshot 2025-10-11 at 10 47 00 PM" src="https://github.com/user-attachments/assets/714b529d-660d-48e6-8ba7-5f5b86cbd877" />
Before:
<img width="1728" height="993" alt="Screenshot 2025-10-11 at 10 47 19 PM" src="https://github.com/user-attachments/assets/afefcccb-89e7-4fa3-86d2-51e3c393df99" />
