### PR TITLE
[Feat] Prevent actions past program completion

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 # --- Environment Constants ---
 ENV_DEVELOPMENT = "development"
 ENV_STAGING = "staging"
@@ -7,6 +9,13 @@ ENV_TESTING = "testing"
 
 # --- Business Logic Constants ---
 BUSINESS_TIMEZONE = "America/Denver"  # Mountain Time for care day locking and business rules
+
+# --- Program End Cutoffs ---
+# First month with no new MonthAllocations and no payment/invite reminders.
+PROGRAM_END_MONTH_START = date(2026, 7, 1)
+# After this date, attendance creation and attendance communications stop. The
+# first week of July (June 29 - July 5) is still attendance-eligible.
+ATTENDANCE_CUTOFF_DATE = date(2026, 7, 7)
 
 # --- Payment Processing Constants ---
 MAX_PAYMENT_AMOUNT_CENTS = 140000  # $1400 maximum per transaction

--- a/app/models/attendance.py
+++ b/app/models/attendance.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime, timezone
 
 from app.supabase.columns import ProviderType
-from app.utils.date_utils import get_relative_week
+from app.utils.date_utils import get_business_today, get_relative_week
 
 from ..extensions import db
 from .mixins import TimestampMixin
@@ -104,7 +104,7 @@ class Attendance(db.Model, TimestampMixin):
             & cls.family_entered_hours.is_(None)  # NOTE: so old attendance doesn't show up
         )
 
-        before_date = get_relative_week(-1)
+        before_date = get_relative_week(-1, get_business_today())
 
         provider_attendance_is_due = (
             cls.provider_entered_full_days.is_(None)

--- a/app/models/month_allocation.py
+++ b/app/models/month_allocation.py
@@ -1,12 +1,11 @@
-from datetime import timedelta
-from datetime import date
+from datetime import date, timedelta
 from typing import Optional
 
 import sentry_sdk
 from flask import current_app
 from sqlalchemy.exc import IntegrityError
 
-from app.constants import MAX_ALLOCATION_AMOUNT_CENTS
+from app.constants import MAX_ALLOCATION_AMOUNT_CENTS, PROGRAM_END_MONTH_START
 from app.supabase.helpers import cols, unwrap_or_error
 from app.supabase.tables import Child
 from app.utils.date_utils import get_current_month_start, get_next_month_start
@@ -235,9 +234,9 @@ class MonthAllocation(db.Model, TimestampMixin):
         if month_start > next_month_start:
             raise ValueError(f"Cannot create allocation for a month more than one month in the future.")
 
-        # Prevent creating allocations for July 2026 and beyond
-        if month_start >= date(2026, 7, 1):
-            raise ValueError(f"Cannot create allocation for July 2026 or beyond.")
+        # Prevent creating allocations on/after the program-end cutoff.
+        if month_start >= PROGRAM_END_MONTH_START:
+            raise ValueError(f"Cannot create allocation for {PROGRAM_END_MONTH_START.strftime('%B %Y')} or beyond.")
 
         # Check if child has payment enabled
         child_results = Child.select_by_id(cols(Child.PAYMENT_ENABLED), int(child_id)).execute()

--- a/app/models/month_allocation.py
+++ b/app/models/month_allocation.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import timedelta
 from typing import Optional
 
 import sentry_sdk

--- a/app/models/month_allocation.py
+++ b/app/models/month_allocation.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from datetime import date
 from typing import Optional
 
 import sentry_sdk
@@ -233,6 +234,10 @@ class MonthAllocation(db.Model, TimestampMixin):
         next_month_start = get_next_month_start()
         if month_start > next_month_start:
             raise ValueError(f"Cannot create allocation for a month more than one month in the future.")
+
+        # Prevent creating allocations for July 2026 and beyond
+        if month_start >= date(2026, 7, 1):
+            raise ValueError(f"Cannot create allocation for July 2026 or beyond.")
 
         # Check if child has payment enabled
         child_results = Child.select_by_id(cols(Child.PAYMENT_ENABLED), int(child_id)).execute()

--- a/app/scripts/create_attendance.py
+++ b/app/scripts/create_attendance.py
@@ -4,6 +4,7 @@ from datetime import date
 from flask import current_app
 
 from app import create_app
+from app.constants import ATTENDANCE_CUTOFF_DATE
 from app.extensions import db
 from app.models import Attendance
 from app.models.allocated_care_day import AllocatedCareDay
@@ -26,11 +27,6 @@ def create_child_provider_attendance(
     if not Provider.PAYMENT_ENABLED(provider):
         return
 
-    # Do not RUN create attendance past July 7th, 2026
-    if get_business_today() >= date(2026, 7, 7):
-        current_app.logger.info("No attendance records will be created after July 7th, 2026.")
-        return
-
     if Provider.TYPE(provider) != ProviderType.CENTER:
         # NOTE: don't create attendance for providers that are not scheduled
         week_start, week_end = last_week_range
@@ -49,6 +45,12 @@ def create_child_provider_attendance(
 
 
 def create_attendance(dry_run=False):
+    # Short-circuit once the program-end attendance cutoff has passed so a
+    # manual rerun in the July 7-12 window doesn't iterate every child/provider.
+    if get_business_today() >= ATTENDANCE_CUTOFF_DATE:
+        current_app.logger.info(f"No attendance records will be created on/after {ATTENDANCE_CUTOFF_DATE.isoformat()}.")
+        return
+
     current_app.logger.info("create_attendance: Starting attendance creation...")
 
     children_result = (
@@ -75,11 +77,6 @@ def create_attendance(dry_run=False):
 
     last_week_date = get_relative_week(-1, get_business_today())
     last_week_range = get_week_range(last_week_date)
-
-    # Do not create attendance past July 1st, 2026
-    if last_week_date >= date(2026, 7, 1):
-        current_app.logger.info("No attendance records will be created after July 1st, 2026.")
-        return
 
     attendances: list[Attendance] = []
     for child in children:

--- a/app/scripts/create_attendance.py
+++ b/app/scripts/create_attendance.py
@@ -26,6 +26,11 @@ def create_child_provider_attendance(
     if not Provider.PAYMENT_ENABLED(provider):
         return
 
+    # Do not create attendance past July 7th, 2026
+    if date.today() >= date(2026, 7, 7):
+        current_app.logger.info("No attendance records will be created after July 7th, 2026.")
+        return
+
     if Provider.TYPE(provider) != ProviderType.CENTER:
         # NOTE: don't create attendance for providers that are not scheduled
         week_start, week_end = last_week_range
@@ -70,6 +75,11 @@ def create_attendance(dry_run=False):
 
     last_week_date = get_relative_week(-1)
     last_week_range = get_week_range(last_week_date)
+
+    # Do not create attendance past July 7th, 2026
+    if last_week_date >= date(2026, 7, 7):
+        current_app.logger.info("No attendance records will be created after July 7th, 2026.")
+        return
 
     attendances: list[Attendance] = []
     for child in children:

--- a/app/scripts/create_attendance.py
+++ b/app/scripts/create_attendance.py
@@ -26,7 +26,7 @@ def create_child_provider_attendance(
     if not Provider.PAYMENT_ENABLED(provider):
         return
 
-    # Do not create attendance past July 7th, 2026
+    # Do not RUN create attendance past July 7th, 2026
     if date.today() >= date(2026, 7, 7):
         current_app.logger.info("No attendance records will be created after July 7th, 2026.")
         return

--- a/app/scripts/create_attendance.py
+++ b/app/scripts/create_attendance.py
@@ -76,9 +76,9 @@ def create_attendance(dry_run=False):
     last_week_date = get_relative_week(-1)
     last_week_range = get_week_range(last_week_date)
 
-    # Do not create attendance past July 7th, 2026
-    if last_week_date >= date(2026, 7, 7):
-        current_app.logger.info("No attendance records will be created after July 7th, 2026.")
+    # Do not create attendance past July 1st, 2026
+    if last_week_date >= date(2026, 7, 1):
+        current_app.logger.info("No attendance records will be created after July 1st, 2026.")
         return
 
     attendances: list[Attendance] = []

--- a/app/scripts/create_attendance.py
+++ b/app/scripts/create_attendance.py
@@ -10,7 +10,7 @@ from app.models.allocated_care_day import AllocatedCareDay
 from app.supabase.columns import ProviderType, Status
 from app.supabase.helpers import cols, unwrap_or_error
 from app.supabase.tables import Child, Family, Provider
-from app.utils.date_utils import get_relative_week, get_week_range
+from app.utils.date_utils import get_business_today, get_relative_week, get_week_range
 
 
 def create_child_provider_attendance(
@@ -27,7 +27,7 @@ def create_child_provider_attendance(
         return
 
     # Do not RUN create attendance past July 7th, 2026
-    if date.today() >= date(2026, 7, 7):
+    if get_business_today() >= date(2026, 7, 7):
         current_app.logger.info("No attendance records will be created after July 7th, 2026.")
         return
 
@@ -73,7 +73,7 @@ def create_attendance(dry_run=False):
     )
     children = unwrap_or_error(children_result)
 
-    last_week_date = get_relative_week(-1)
+    last_week_date = get_relative_week(-1, get_business_today())
     last_week_range = get_week_range(last_week_date)
 
     # Do not create attendance past July 1st, 2026

--- a/app/scripts/create_monthly_allocations.py
+++ b/app/scripts/create_monthly_allocations.py
@@ -68,7 +68,7 @@ def create_allocations_for_month(target_month: date, dry_run: bool = False) -> d
                 else:
                     print(f"✅ {child_name} ({child_id}) - Created{amount_str}")
             elif status == "skipped":
-                print(f"⏭️  {child_name} ({child_id}) - Already exists")
+                print(f"⏭️  {child_name} ({child_id}) - Skipped")
             elif status == "error":
                 print(f"❌ {child_name} ({child_id}) - Failed")
 

--- a/app/scripts/send_attendance_communications.py
+++ b/app/scripts/send_attendance_communications.py
@@ -1,6 +1,6 @@
 import argparse
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from flask import current_app
 
@@ -273,6 +273,11 @@ class ProviderAttendanceMessages(AttendanceMessages):
 
 
 def send_attendance_communications(send_to_families=False, send_to_providers=False, dry_run=False):
+    # Past July 1st 2026, we will no longer send attendance communications
+    if date.today() >= date(2026, 7, 7):
+        current_app.logger.info("No attendance communications will be sent after July 7th, 2026.")
+        return
+
     current_app.logger.info("create_attendance: Starting attendance creation...")
     bulk_emails: list[BulkEmailData] = []
     bulk_text_messages: list[BulkSmsData] = []

--- a/app/scripts/send_attendance_communications.py
+++ b/app/scripts/send_attendance_communications.py
@@ -1,10 +1,11 @@
 import argparse
 from dataclasses import dataclass
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 from flask import current_app
 
 from app import create_app
+from app.constants import ATTENDANCE_CUTOFF_DATE
 from app.enums.email_type import EmailType
 from app.models.attendance import Attendance
 from app.services.payment.utils import format_phone_to_e164
@@ -274,9 +275,11 @@ class ProviderAttendanceMessages(AttendanceMessages):
 
 
 def send_attendance_communications(send_to_families=False, send_to_providers=False, dry_run=False):
-    # Past July 7th 2026, we will no longer send attendance communications
-    if get_business_today() >= date(2026, 7, 7):
-        current_app.logger.info("No attendance communications will be sent after July 7th, 2026.")
+    # Past the attendance cutoff, we will no longer send attendance communications.
+    if get_business_today() >= ATTENDANCE_CUTOFF_DATE:
+        current_app.logger.info(
+            f"No attendance communications will be sent on/after {ATTENDANCE_CUTOFF_DATE.isoformat()}."
+        )
         return
 
     current_app.logger.info("create_attendance: Starting attendance creation...")

--- a/app/scripts/send_attendance_communications.py
+++ b/app/scripts/send_attendance_communications.py
@@ -11,6 +11,7 @@ from app.services.payment.utils import format_phone_to_e164
 from app.supabase.columns import Language, ProviderType
 from app.supabase.helpers import cols, unwrap_or_error
 from app.supabase.tables import Child, Family, Guardian, Provider
+from app.utils.date_utils import get_business_today
 from app.utils.email.config import get_from_email_external
 from app.utils.email.core import (
     BulkEmailData,
@@ -274,7 +275,7 @@ class ProviderAttendanceMessages(AttendanceMessages):
 
 def send_attendance_communications(send_to_families=False, send_to_providers=False, dry_run=False):
     # Past July 7th 2026, we will no longer send attendance communications
-    if date.today() >= date(2026, 7, 7):
+    if get_business_today() >= date(2026, 7, 7):
         current_app.logger.info("No attendance communications will be sent after July 7th, 2026.")
         return
 

--- a/app/scripts/send_attendance_communications.py
+++ b/app/scripts/send_attendance_communications.py
@@ -273,7 +273,7 @@ class ProviderAttendanceMessages(AttendanceMessages):
 
 
 def send_attendance_communications(send_to_families=False, send_to_providers=False, dry_run=False):
-    # Past July 1st 2026, we will no longer send attendance communications
+    # Past July 7th 2026, we will no longer send attendance communications
     if date.today() >= date(2026, 7, 7):
         current_app.logger.info("No attendance communications will be sent after July 7th, 2026.")
         return

--- a/app/scripts/send_invite_reminders.py
+++ b/app/scripts/send_invite_reminders.py
@@ -1,10 +1,11 @@
 import argparse
 from dataclasses import dataclass
-from datetime import datetime, timezone, date
+from datetime import datetime, timezone
 
 from flask import current_app
 
 from app import create_app
+from app.constants import PROGRAM_END_MONTH_START
 from app.enums.email_type import EmailType
 from app.models.provider_invitation import ProviderInvitation
 from app.services.payment.utils import format_phone_to_e164
@@ -60,9 +61,9 @@ def message(family_name: str, default_child_id: str, language: Language):
 
 
 def send_invite_reminders(dry_run=False):
-    # Past July 1st 2026, we will no longer send invite reminders
-    if get_business_today() >= date(2026, 7, 1):
-        current_app.logger.info("No invite reminders will be sent after July 1st, 2026.")
+    # Past the program-end cutoff, we will no longer send invite reminders.
+    if get_business_today() >= PROGRAM_END_MONTH_START:
+        current_app.logger.info(f"No invite reminders will be sent on/after {PROGRAM_END_MONTH_START.isoformat()}.")
         return
 
     family_result = (

--- a/app/scripts/send_invite_reminders.py
+++ b/app/scripts/send_invite_reminders.py
@@ -1,6 +1,6 @@
 import argparse
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date
 
 from flask import current_app
 
@@ -59,6 +59,11 @@ def message(family_name: str, default_child_id: str, language: Language):
 
 
 def send_invite_reminders(dry_run=False):
+    # Past July 1st 2026, we will no longer send invite reminders
+    if date.today() >= date(2026, 7, 1):
+        current_app.logger.info("No invite reminders will be sent after July 1st, 2026.")
+        return
+
     family_result = (
         Family.query()
         .select(

--- a/app/scripts/send_invite_reminders.py
+++ b/app/scripts/send_invite_reminders.py
@@ -11,6 +11,7 @@ from app.services.payment.utils import format_phone_to_e164
 from app.supabase.columns import Language, Status
 from app.supabase.helpers import cols, unwrap_or_error
 from app.supabase.tables import Child, Family, Guardian, Provider
+from app.utils.date_utils import get_business_today
 from app.utils.email.config import get_from_email_external
 from app.utils.email.core import BulkEmailData, bulk_send_emails
 from app.utils.email.senders import html_link
@@ -60,7 +61,7 @@ def message(family_name: str, default_child_id: str, language: Language):
 
 def send_invite_reminders(dry_run=False):
     # Past July 1st 2026, we will no longer send invite reminders
-    if date.today() >= date(2026, 7, 1):
+    if get_business_today() >= date(2026, 7, 1):
         current_app.logger.info("No invite reminders will be sent after July 1st, 2026.")
         return
 

--- a/app/scripts/send_payment_reminders.py
+++ b/app/scripts/send_payment_reminders.py
@@ -105,6 +105,11 @@ def should_send_reminder(child: dict, week_range: tuple[date, date]):
 
 
 def send_payment_reminders(dry_run=False):
+    # Past July 1st 2026, we will no longer send payment reminders
+    if date.today() >= date(2026, 7, 1):
+        current_app.logger.info("No payment reminders will be sent after July 1st, 2026.")
+        return
+
     family_result = (
         Family.query()
         .select(

--- a/app/scripts/send_payment_reminders.py
+++ b/app/scripts/send_payment_reminders.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 from flask import current_app
 
 from app import create_app
+from app.constants import PROGRAM_END_MONTH_START
 from app.enums.email_type import EmailType
 from app.models.allocated_care_day import AllocatedCareDay
 from app.models.month_allocation import MonthAllocation
@@ -110,13 +111,13 @@ def send_payment_reminders(dry_run=False):
     next_week_range = get_week_range(get_relative_week(1, get_business_today()))
     _, next_week_end = next_week_range
 
-    # July 2026 allocations are not created, so a reminder for a week whose
-    # allocation month is July or later has nothing to pay against. This also
-    # catches the late-June Friday run whose next-week range crosses into July.
-    if next_week_end.replace(day=1) >= date(2026, 7, 1):
+    # If the next week's allocation month is past the program-end cutoff, there
+    # is nothing to pay against. This also catches the late-June Friday run whose
+    # next-week range crosses into the cutoff month.
+    if next_week_end.replace(day=1) >= PROGRAM_END_MONTH_START:
         current_app.logger.info(
             f"No payment reminders will be sent for week ending {next_week_end.isoformat()} "
-            "(no allocations on/after July 2026)."
+            f"(no allocations on/after {PROGRAM_END_MONTH_START.isoformat()})."
         )
         return
 

--- a/app/scripts/send_payment_reminders.py
+++ b/app/scripts/send_payment_reminders.py
@@ -105,9 +105,17 @@ def should_send_reminder(child: dict, week_range: tuple[date, date]):
 
 
 def send_payment_reminders(dry_run=False):
-    # Past July 1st 2026, we will no longer send payment reminders
-    if date.today() >= date(2026, 7, 1):
-        current_app.logger.info("No payment reminders will be sent after July 1st, 2026.")
+    next_week_range = get_week_range(get_relative_week(1))
+    _, next_week_end = next_week_range
+
+    # July 2026 allocations are not created, so a reminder for a week whose
+    # allocation month is July or later has nothing to pay against. This also
+    # catches the late-June Friday run whose next-week range crosses into July.
+    if next_week_end.replace(day=1) >= date(2026, 7, 1):
+        current_app.logger.info(
+            f"No payment reminders will be sent for week ending {next_week_end.isoformat()} "
+            "(no allocations on/after July 2026)."
+        )
         return
 
     family_result = (
@@ -138,8 +146,6 @@ def send_payment_reminders(dry_run=False):
         .execute()
     )
     families = unwrap_or_error(family_result)
-
-    next_week_range = get_week_range(get_relative_week(1))
 
     emails: list[BulkEmailData] = []
     sms: list[BulkSmsData] = []

--- a/app/scripts/send_payment_reminders.py
+++ b/app/scripts/send_payment_reminders.py
@@ -78,7 +78,12 @@ def should_send_reminder(child: dict, week_range: tuple[date, date]):
         return False
 
     week_start, week_end = week_range
-    month_allocation = MonthAllocation.get_for_month(Child.ID(child), week_end)
+    # Look up by week_start so a cross-month week (e.g., Jun 29 - Jul 5) anchors
+    # on the start month's allocation, which is the one that covers the still-
+    # payable days when the end month is past the program cutoff.
+    month_allocation = MonthAllocation.get_for_month(Child.ID(child), week_start)
+    if month_allocation is None:
+        return False
 
     has_payable_provider = False
     providers = Provider.unwrap(child)
@@ -109,14 +114,14 @@ def send_payment_reminders(dry_run=False):
     # Anchor on business-timezone "today" so the cutoff flips at midnight Mountain
     # Time regardless of the host's local timezone.
     next_week_range = get_week_range(get_relative_week(1, get_business_today()))
-    _, next_week_end = next_week_range
+    next_week_start, _ = next_week_range
 
-    # If the next week's allocation month is past the program-end cutoff, there
-    # is nothing to pay against. This also catches the late-June Friday run whose
-    # next-week range crosses into the cutoff month.
-    if next_week_end.replace(day=1) >= PROGRAM_END_MONTH_START:
+    # Skip only when next week's start month is past the program-end cutoff. A
+    # cross-month week (e.g., Jun 29 - Jul 5) still runs so families get reminded
+    # about the start-month days that remain payable.
+    if next_week_start.replace(day=1) >= PROGRAM_END_MONTH_START:
         current_app.logger.info(
-            f"No payment reminders will be sent for week ending {next_week_end.isoformat()} "
+            f"No payment reminders will be sent for week starting {next_week_start.isoformat()} "
             f"(no allocations on/after {PROGRAM_END_MONTH_START.isoformat()})."
         )
         return

--- a/app/scripts/send_payment_reminders.py
+++ b/app/scripts/send_payment_reminders.py
@@ -11,7 +11,7 @@ from app.models.month_allocation import MonthAllocation
 from app.supabase.columns import Language, ProviderType, Status
 from app.supabase.helpers import cols, unwrap_or_error
 from app.supabase.tables import Child, Family, Guardian, Provider
-from app.utils.date_utils import get_relative_week, get_week_range
+from app.utils.date_utils import get_business_today, get_relative_week, get_week_range
 from app.utils.email.config import get_from_email_external
 from app.utils.email.core import BulkEmailData, bulk_send_emails
 from app.utils.email.senders import html_link
@@ -105,7 +105,9 @@ def should_send_reminder(child: dict, week_range: tuple[date, date]):
 
 
 def send_payment_reminders(dry_run=False):
-    next_week_range = get_week_range(get_relative_week(1))
+    # Anchor on business-timezone "today" so the cutoff flips at midnight Mountain
+    # Time regardless of the host's local timezone.
+    next_week_range = get_week_range(get_relative_week(1, get_business_today()))
     _, next_week_end = next_week_range
 
     # July 2026 allocations are not created, so a reminder for a week whose

--- a/app/services/allocation_service.py
+++ b/app/services/allocation_service.py
@@ -173,6 +173,11 @@ class AllocationService:
 
         self.app.logger.info(f"Processing allocation for {child_name} ({child_id}) for {target_month}")
 
+        # If July 2026 or later, skip allocation creation
+        if target_month >= date(2026, 7, 1):
+            self.app.logger.info(f"Skipping allocation for {child_name} ({child_id}) for {target_month} (after cutoff)")
+            return ("skipped", None, None)
+
         # Validate child ID
         if not child_id:
             error_msg = f"Missing ID for child: {child_name}"

--- a/app/services/allocation_service.py
+++ b/app/services/allocation_service.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 import sentry_sdk
 from flask import current_app
 
+from app.constants import PROGRAM_END_MONTH_START
 from app.supabase.helpers import cols, format_name, unwrap_or_error
 from app.supabase.tables import Child
 
@@ -173,8 +174,8 @@ class AllocationService:
 
         self.app.logger.info(f"Processing allocation for {child_name} ({child_id}) for {target_month}")
 
-        # If July 2026 or later, skip allocation creation
-        if target_month >= date(2026, 7, 1):
+        # If past the program-end cutoff, skip allocation creation
+        if target_month >= PROGRAM_END_MONTH_START:
             self.app.logger.info(f"Skipping allocation for {child_name} ({child_id}) for {target_month} (after cutoff)")
             return ("skipped", None, None)
 

--- a/app/utils/date_utils.py
+++ b/app/utils/date_utils.py
@@ -9,10 +9,13 @@ def get_month_start(date: date) -> date:
     return date.replace(day=1)
 
 
-def get_current_month_start() -> date:
+def get_business_today() -> date:
     business_tz = zoneinfo.ZoneInfo(BUSINESS_TIMEZONE)
-    now_business = datetime.now(business_tz)
-    return get_month_start(now_business.date())
+    return datetime.now(business_tz).date()
+
+
+def get_current_month_start() -> date:
+    return get_month_start(get_business_today())
 
 
 def get_next_month_start() -> date:

--- a/tests/models/test_month_allocation.py
+++ b/tests/models/test_month_allocation.py
@@ -1,9 +1,21 @@
-from datetime import date, datetime, timedelta
+from contextlib import contextmanager
+from datetime import date, datetime
 from unittest.mock import patch
 
 import pytest
 
 from app.models.month_allocation import MonthAllocation, get_allocation_amount
+
+
+@contextmanager
+def frozen_business_clock(today: date):
+    """Pin date_utils.datetime.now(...) to `today` so pre/post-cutoff behavior
+    doesn't depend on when the test suite happens to run."""
+    with patch("app.utils.date_utils.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(today.year, today.month, today.day)
+        mock_dt.date.today.return_value = today
+        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        yield
 
 
 def test_get_allocation_amount_prorated(db_session, app):
@@ -21,23 +33,26 @@ def test_get_allocation_amount_normal(month_allocation, app):
     assert amount == 100000  # monthly_allocation * 100
 
 
-def test_get_or_create_for_month_existing(month_allocation):
+def test_get_or_create_for_month_existing(db_session):
     """Test that the existing allocation is returned"""
-    today = date.today()
-    allocation = MonthAllocation.get_or_create_for_month(child_id=month_allocation.child_supabase_id, month_date=today)
-    assert allocation == month_allocation
+    existing = MonthAllocation(child_supabase_id="1", date=date(2026, 3, 1), allocation_cents=100000)
+    db_session.add(existing)
+    db_session.commit()
+
+    with frozen_business_clock(date(2026, 3, 15)):
+        allocation = MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 3, 1))
+    assert allocation == existing
 
 
 @patch("app.models.month_allocation.get_allocation_amount")
 def test_get_or_create_for_month_new(mock_get_allocation_amount, db_session):
     """Test that a new allocation is created"""
-    # Mock the allocation amount function
     mock_get_allocation_amount.return_value = 50000
 
-    today = date.today()
-    allocation = MonthAllocation.get_or_create_for_month(child_id="1", month_date=today)
+    with frozen_business_clock(date(2026, 3, 15)):
+        allocation = MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 3, 15))
     assert allocation.child_supabase_id == "1"
-    assert allocation.date == today.replace(day=1)
+    assert allocation.date == date(2026, 3, 1)
     assert allocation.allocation_cents == 50000
 
 
@@ -49,61 +64,43 @@ def test_get_or_create_for_month_past(db_session):
 
 def test_get_or_create_for_month_future(db_session):
     """Test that an error is raised when creating an allocation for a future month that is more than one month away"""
-    with pytest.raises(ValueError, match="Cannot create allocation for a month more than one month in the future."):
-        MonthAllocation.get_or_create_for_month(child_id="1", month_date=date.today() + timedelta(days=65))
+    with frozen_business_clock(date(2026, 3, 15)):
+        with pytest.raises(ValueError, match="Cannot create allocation for a month more than one month in the future."):
+            MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 6, 1))
 
 
 @patch("app.models.month_allocation.get_allocation_amount")
 def test_get_or_create_for_month_next_month_allowed(mock_get_allocation_amount, db_session):
     """Test that a new allocation for the next month can be created"""
-    # Mock the allocation amount function
     mock_get_allocation_amount.return_value = 50000
 
-    # Simulate being on the first day of the month
-    with patch("app.utils.date_utils.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime(date.today().year, date.today().month, 1)
-        mock_dt.date.today.return_value = date(date.today().year, date.today().month, 1)
-        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)  # Ensure other datetime calls work
-
-        today = date.today()
-        # Calculate the first day of the next month
-        next_month_date = (today.replace(day=1) + timedelta(days=32)).replace(day=1)
-
-        allocation = MonthAllocation.get_or_create_for_month(child_id="1", month_date=next_month_date)
-        assert allocation.child_supabase_id == "1"
-        assert allocation.date == next_month_date
-        assert allocation.allocation_cents == 50000
+    with frozen_business_clock(date(2026, 3, 1)):
+        allocation = MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 4, 1))
+    assert allocation.child_supabase_id == "1"
+    assert allocation.date == date(2026, 4, 1)
+    assert allocation.allocation_cents == 50000
 
 
 @patch("app.models.month_allocation.get_allocation_amount")
-def test_get_or_create_for_month_july_2026_rejected(mock_get_allocation_amount, db_session):
-    """Test that creating an allocation for July 2026 is rejected by the program-end cutoff."""
-    mock_get_allocation_amount.return_value = 50000
-
-    # Simulate being in June 2026 so July 2026 passes the "next month" check
-    # and the rejection comes specifically from the July 2026 cutoff.
-    with patch("app.utils.date_utils.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime(2026, 6, 1)
-        mock_dt.date.today.return_value = date(2026, 6, 1)
-        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
-
-        with pytest.raises(ValueError, match="Cannot create allocation for July 2026 or beyond."):
+def test_get_or_create_for_month_cutoff_rejected(mock_get_allocation_amount, db_session):
+    """Allocations on/after the program-end cutoff are rejected."""
+    # Simulate being in the month before the cutoff so the cutoff month passes
+    # the "next month" check and the rejection comes specifically from the cutoff.
+    with frozen_business_clock(date(2026, 6, 1)):
+        with pytest.raises(ValueError, match="Cannot create allocation for .* or beyond."):
             MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 7, 1))
 
+    # The cutoff fires before any allocation amount lookup.
+    mock_get_allocation_amount.assert_not_called()
+
 
 @patch("app.models.month_allocation.get_allocation_amount")
-def test_get_or_create_for_month_june_2026_allowed(mock_get_allocation_amount, db_session):
-    """Test that creating an allocation for June 2026 is allowed (last month before the cutoff)."""
+def test_get_or_create_for_month_last_month_before_cutoff_allowed(mock_get_allocation_amount, db_session):
+    """The last month before the cutoff is still creatable."""
     mock_get_allocation_amount.return_value = 50000
 
-    # Simulate being in May 2026 so June 2026 is "next month" and sits just
-    # below the July 2026 cutoff.
-    with patch("app.utils.date_utils.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime(2026, 5, 1)
-        mock_dt.date.today.return_value = date(2026, 5, 1)
-        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
-
+    with frozen_business_clock(date(2026, 5, 1)):
         allocation = MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 6, 1))
-        assert allocation.child_supabase_id == "1"
-        assert allocation.date == date(2026, 6, 1)
-        assert allocation.allocation_cents == 50000
+    assert allocation.child_supabase_id == "1"
+    assert allocation.date == date(2026, 6, 1)
+    assert allocation.allocation_cents == 50000

--- a/tests/models/test_month_allocation.py
+++ b/tests/models/test_month_allocation.py
@@ -73,3 +73,37 @@ def test_get_or_create_for_month_next_month_allowed(mock_get_allocation_amount, 
         assert allocation.child_supabase_id == "1"
         assert allocation.date == next_month_date
         assert allocation.allocation_cents == 50000
+
+
+@patch("app.models.month_allocation.get_allocation_amount")
+def test_get_or_create_for_month_july_2026_rejected(mock_get_allocation_amount, db_session):
+    """Test that creating an allocation for July 2026 is rejected by the program-end cutoff."""
+    mock_get_allocation_amount.return_value = 50000
+
+    # Simulate being in June 2026 so July 2026 passes the "next month" check
+    # and the rejection comes specifically from the July 2026 cutoff.
+    with patch("app.utils.date_utils.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 6, 1)
+        mock_dt.date.today.return_value = date(2026, 6, 1)
+        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        with pytest.raises(ValueError, match="Cannot create allocation for July 2026 or beyond."):
+            MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 7, 1))
+
+
+@patch("app.models.month_allocation.get_allocation_amount")
+def test_get_or_create_for_month_june_2026_allowed(mock_get_allocation_amount, db_session):
+    """Test that creating an allocation for June 2026 is allowed (last month before the cutoff)."""
+    mock_get_allocation_amount.return_value = 50000
+
+    # Simulate being in May 2026 so June 2026 is "next month" and sits just
+    # below the July 2026 cutoff.
+    with patch("app.utils.date_utils.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 5, 1)
+        mock_dt.date.today.return_value = date(2026, 5, 1)
+        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+        allocation = MonthAllocation.get_or_create_for_month(child_id="1", month_date=date(2026, 6, 1))
+        assert allocation.child_supabase_id == "1"
+        assert allocation.date == date(2026, 6, 1)
+        assert allocation.allocation_cents == 50000


### PR DESCRIPTION
Prevent a number of actions past the end date of CAP:
- Payment allocations cannot be made for July
- Creating after the first week of July is over
- Prevent payment and attendance reminders from going out